### PR TITLE
Fix service worker cache to avoid install failure

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,13 +1,24 @@
+// During installation, cache the core assets needed to run the app offline.
+// The previous implementation attempted to cache files that don't exist in the
+// Next.js build output (e.g. `/index.html` and `/xo-game.js`). Including
+// non‑existent files causes the `install` step to reject, preventing the service
+// worker from installing at all. We now only cache valid static assets.
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open('xo-game-v1').then((cache) => {
-      return cache.addAll([
-        '/',
-        '/index.html',
-        '/xo-game.js',
-        '/icon-192x192.jpg',
-        '/icon-512x512.jpg',
-      ])
+      return cache
+        .addAll([
+          '/',
+          '/favicon.ico',
+          '/icon-192x192.jpg',
+          '/icon-512x512.jpg',
+          '/site.webmanifest',
+        ])
+        .catch((err) => {
+          // If any asset fails to cache, log the error but allow installation
+          // to proceed so that at least some assets are available offline.
+          console.error('Service Worker cache install failed', err)
+        })
     })
   )
 })


### PR DESCRIPTION
## Summary
- prevent service worker install failures by caching only valid assets
- add error handling while caching during installation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68978daf5914832c97548cdb0d63b288