### PR TITLE
fix: self-close manifest link in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-        <link rel="manifest" href="/site.webmanifest"></link>
+        <link rel="manifest" href="/site.webmanifest" />
       </head>
       <body className={inter.className}>{children}</body>
     </html> 


### PR DESCRIPTION
## Summary
- use self-closing manifest link in HTML layout for validity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897903b99dc832c9777a2eccfff9641