### PR TITLE
docs: mention Inter font usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) via [`next/font/google`](https://nextjs.org/docs/app/api-reference/components/next-font#google-fonts) to automatically optimize and load the [Inter](https://fonts.google.com/specimen/Inter) font from Google Fonts.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- document Inter font usage via next/font/google in README to match app layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897921b82f4832c89cdb213024f38a2