### PR TITLE
Generalize winner detection over board coordinates

### DIFF
--- a/components/__tests__/xo-game.test.tsx
+++ b/components/__tests__/xo-game.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, test } from 'vitest'
-import { checkWinner, type Player, type Board } from '../../lib/check-winner'
+import { describe, it, expect, test } from "vitest"
+import { checkWinner, type Player, type Board } from "../../lib/check-winner"
 
 describe('checkWinner', () => {
   const lines: number[][] = [

--- a/components/__tests__/xo-game.test.tsx
+++ b/components/__tests__/xo-game.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, test } from 'vitest'
-import { checkWinner, type Player } from '../../lib/check-winner'
+import { checkWinner, type Player, type Board } from '../../lib/check-winner'
 
 describe('checkWinner', () => {
   const lines: number[][] = [
@@ -13,25 +13,42 @@ describe('checkWinner', () => {
     [2, 4, 6],
   ]
 
+  const createBoard = (): Board =>
+    Array.from({ length: 3 }, () => Array<Player>(3).fill(null))
+
+  const toBoard = (flat: Player[]): Board => [
+    flat.slice(0, 3),
+    flat.slice(3, 6),
+    flat.slice(6, 9),
+  ]
+
   test.each(lines)('detects X win for positions %o', (a, b, c) => {
-    const board: Player[] = Array(9).fill(null)
-    board[a] = board[b] = board[c] = 'X'
+    const board = createBoard()
+    ;[a, b, c].forEach((index) => {
+      const row = Math.floor(index / 3)
+      const col = index % 3
+      board[row][col] = 'X'
+    })
     expect(checkWinner(board)).toBe('X')
   })
 
   test.each(lines)('detects O win for positions %o', (a, b, c) => {
-    const board: Player[] = Array(9).fill(null)
-    board[a] = board[b] = board[c] = 'O'
+    const board = createBoard()
+    ;[a, b, c].forEach((index) => {
+      const row = Math.floor(index / 3)
+      const col = index % 3
+      board[row][col] = 'O'
+    })
     expect(checkWinner(board)).toBe('O')
   })
 
   it('returns null for a draw', () => {
-    const board: Player[] = ['X','O','X','X','O','O','O','X','X']
+    const board = toBoard(['X','O','X','X','O','O','O','X','X'])
     expect(checkWinner(board)).toBeNull()
   })
 
   it('returns null for a non-terminal state', () => {
-    const board: Player[] = ['X','O','X',null,'O',null,null,'X',null]
+    const board = toBoard(['X','O','X',null,'O',null,null,'X',null])
     expect(checkWinner(board)).toBeNull()
   })
 })

--- a/components/xo-game.tsx
+++ b/components/xo-game.tsx
@@ -4,9 +4,12 @@ import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { checkWinner, type Player, type Board } from "@/lib/check-winner"
 
+const BOARD_SIZE = 3
+
+const createEmptyBoard = (): Board =>
+  Array.from({ length: BOARD_SIZE }, () => Array<Player>(BOARD_SIZE).fill(null))
+
 const XOGame = () => {
-  const createEmptyBoard = (): Board =>
-    Array.from({ length: 3 }, () => Array<Player>(3).fill(null))
 
   const [board, setBoard] = useState<Board>(createEmptyBoard())
   const [currentPlayer, setCurrentPlayer] = useState<'X' | 'O'>('X')

--- a/components/xo-game.tsx
+++ b/components/xo-game.tsx
@@ -2,10 +2,13 @@
 
 import { useState, useEffect } from 'react'
 import { Button } from "@/components/ui/button"
-import { checkWinner, type Player } from '../lib/check-winner'
+import { checkWinner, type Player, type Board } from '../lib/check-winner'
 
 const XOGame = () => {
-  const [board, setBoard] = useState<Player[]>(Array(9).fill(null))
+  const createEmptyBoard = (): Board =>
+    Array.from({ length: 3 }, () => Array<Player>(3).fill(null))
+
+  const [board, setBoard] = useState<Board>(createEmptyBoard())
   const [currentPlayer, setCurrentPlayer] = useState<'X' | 'O'>('X')
   const [winner, setWinner] = useState<Player>(null)
   const [deferredPrompt, setDeferredPrompt] = useState<any>(null)
@@ -40,11 +43,11 @@ const XOGame = () => {
     }
   }
 
-  const handleClick = (index: number) => {
-    if (board[index] || winner) return
+  const handleClick = (row: number, col: number) => {
+    if (board[row][col] || winner) return
 
-    const newBoard = [...board]
-    newBoard[index] = currentPlayer
+    const newBoard = board.map((r) => r.slice())
+    newBoard[row][col] = currentPlayer
     setBoard(newBoard)
 
     const newWinner = checkWinner(newBoard)
@@ -56,7 +59,7 @@ const XOGame = () => {
   }
 
   const resetGame = () => {
-    setBoard(Array(9).fill(null))
+    setBoard(createEmptyBoard())
     setCurrentPlayer('X')
     setWinner(null)
   }
@@ -65,22 +68,24 @@ const XOGame = () => {
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
       <h1 className="text-4xl font-bold mb-8">Tic-Tac-Toe</h1>
       <div className="grid grid-cols-3 gap-2 mb-4">
-        {board.map((cell, index) => (
-          <Button
-            key={index}
-            onClick={() => handleClick(index)}
-            className="w-20 h-20 text-4xl font-bold"
-            variant={cell ? "default" : "outline"}
-            disabled={!!cell || !!winner}
-          >
-            {cell}
-          </Button>
-        ))}
+        {board.map((row, rowIndex) =>
+          row.map((cell, colIndex) => (
+            <Button
+              key={`${rowIndex}-${colIndex}`}
+              onClick={() => handleClick(rowIndex, colIndex)}
+              className="w-20 h-20 text-4xl font-bold"
+              variant={cell ? "default" : "outline"}
+              disabled={!!cell || !!winner}
+            >
+              {cell}
+            </Button>
+          ))
+        )}
       </div>
       <div className="text-2xl font-semibold mb-4">
         {winner
           ? `Winner: ${winner}`
-          : board.every((cell) => cell !== null)
+          : board.flat().every((cell) => cell !== null)
           ? "It's a draw!"
           : `Current player: ${currentPlayer}`}
       </div>

--- a/components/xo-game.tsx
+++ b/components/xo-game.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
-import { checkWinner, type Player, type Board } from '../lib/check-winner'
+import { checkWinner, type Player, type Board } from "@/lib/check-winner"
 
 const XOGame = () => {
   const createEmptyBoard = (): Board =>

--- a/components/xo-game.tsx
+++ b/components/xo-game.tsx
@@ -68,7 +68,7 @@ const XOGame = () => {
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
       <h1 className="text-4xl font-bold mb-8">Tic-Tac-Toe</h1>
       <div className="grid grid-cols-3 gap-2 mb-4">
-        {board.map((row, rowIndex) =>
+        {board.flatMap((row, rowIndex) =>
           row.map((cell, colIndex) => (
             <Button
               key={`${rowIndex}-${colIndex}`}

--- a/lib/check-winner.ts
+++ b/lib/check-winner.ts
@@ -1,22 +1,40 @@
 export type Player = 'X' | 'O' | null
 
-export const checkWinner = (board: Player[]): Player => {
-  const lines = [
-    [0, 1, 2],
-    [3, 4, 5],
-    [6, 7, 8],
-    [0, 3, 6],
-    [1, 4, 7],
-    [2, 5, 8],
-    [0, 4, 8],
-    [2, 4, 6],
-  ]
+export type Board = Player[][]
 
-  for (const [a, b, c] of lines) {
-    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
-      return board[a]
+export const checkWinner = (board: Board): Player => {
+  const rows = board.length
+  const cols = board[0]?.length ?? 0
+  const directions = [
+    [0, 1], // right
+    [1, 0], // down
+    [1, 1], // down-right
+    [1, -1], // down-left
+  ] as const
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const player = board[r][c]
+      if (!player) continue
+
+      for (const [dr, dc] of directions) {
+        const r1 = r + dr
+        const c1 = c + dc
+        const r2 = r + 2 * dr
+        const c2 = c + 2 * dc
+
+        if (
+          r2 >= 0 && r2 < rows &&
+          c2 >= 0 && c2 < cols &&
+          board[r1][c1] === player &&
+          board[r2][c2] === player
+        ) {
+          return player
+        }
+      }
     }
   }
 
   return null
 }
+


### PR DESCRIPTION
## Summary
- detect wins by scanning each occupied square in four directions instead of using a static line list
- represent the game board as a 2D array and update the XOGame component accordingly
- adjust tests to build 2D boards and verify win detection, draws, and non-terminal states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689797d098c8832c85f729ec2954a115