### PR TITLE
test: add off-origin win and scattered token cases

### DIFF
--- a/components/__tests__/xo-game.test.tsx
+++ b/components/__tests__/xo-game.test.tsx
@@ -2,16 +2,16 @@ import { describe, it, expect } from 'vitest'
 import { checkWinner, type Board } from '../../lib/check-winner'
 
 describe('checkWinner', () => {
-  it('detects a horizontal win', () => {
+  it('detects a horizontal win away from the origin', () => {
     const board: Board = {
-      '0,0': 'X',
-      '0,1': 'X',
-      '0,2': 'X',
+      '5,5': 'X',
+      '5,6': 'X',
+      '5,7': 'X',
     }
     expect(checkWinner(board)).toBe('X')
   })
 
-  it('detects a vertical win', () => {
+  it('detects a vertical win away from the origin', () => {
     const board: Board = {
       '5,5': 'O',
       '6,5': 'O',
@@ -20,20 +20,20 @@ describe('checkWinner', () => {
     expect(checkWinner(board)).toBe('O')
   })
 
-  it('detects a diagonal win', () => {
+  it('detects a diagonal win away from the origin', () => {
     const board: Board = {
-      '1,1': 'X',
-      '2,2': 'X',
-      '3,3': 'X',
+      '5,5': 'X',
+      '6,6': 'X',
+      '7,7': 'X',
     }
     expect(checkWinner(board)).toBe('X')
   })
 
-  it('detects an anti-diagonal win', () => {
+  it('detects an anti-diagonal win away from the origin', () => {
     const board: Board = {
-      '3,1': 'O',
-      '2,2': 'O',
-      '1,3': 'O',
+      '7,5': 'O',
+      '6,6': 'O',
+      '5,7': 'O',
     }
     expect(checkWinner(board)).toBe('O')
   })
@@ -47,11 +47,13 @@ describe('checkWinner', () => {
     expect(checkWinner(board)).toBeNull()
   })
 
-  it('returns null for a non-terminal state', () => {
+  it('returns null when tokens are scattered without forming a line', () => {
     const board: Board = {
-      '0,0': 'X', '0,1': 'O', '0,2': 'X',
-      '1,1': 'O',
-      '3,3': 'X',
+      '0,0': 'X',
+      '2,5': 'O',
+      '5,1': 'X',
+      '8,8': 'O',
+      '9,3': 'X',
     }
     expect(checkWinner(board)).toBeNull()
   })


### PR DESCRIPTION
## Summary
- update checkWinner tests to build boards via coordinate map
- cover horizontal, vertical, diagonal, and anti-diagonal wins starting away from origin
- ensure no winner when pieces are scattered without forming lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a3c97ad0832ca7427206c05cffdd