### PR TITLE
feat: add themed colors for game

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,8 +26,11 @@ body {
     --secondary-foreground: 0 0% 9%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --accent: 142 71% 45%;
+    --accent-foreground: 0 0% 98%;
+    --x-color: 221 83% 53%;
+    --o-color: 14 90% 58%;
+    --board-bg: 210 40% 96%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 89.8%;
@@ -53,8 +56,11 @@ body {
     --secondary-foreground: 0 0% 98%;
     --muted: 0 0% 14.9%;
     --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
+    --accent: 142 71% 45%;
     --accent-foreground: 0 0% 98%;
+    --x-color: 221 83% 53%;
+    --o-color: 14 90% 58%;
+    --board-bg: 210 40% 96%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 14.9%;

--- a/components/xo-game.tsx
+++ b/components/xo-game.tsx
@@ -104,7 +104,7 @@ const XOGame = () => {
 
   if (!gameStarted) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+      <div className="flex flex-col items-center justify-center min-h-screen bg-[hsl(var(--board-bg))]">
         <h1 className="text-4xl font-bold mb-8">Tic-Tac-Toe</h1>
         <div className="flex gap-4 mb-4">
           <Button disabled>1 Player (bot)</Button>
@@ -115,13 +115,18 @@ const XOGame = () => {
             2 Players
           </Button>
         </div>
-        <Button onClick={() => setGameStarted(true)}>Start</Button>
+        <Button
+          onClick={() => setGameStarted(true)}
+          className="bg-accent text-accent-foreground hover:bg-accent/90"
+        >
+          Start
+        </Button>
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex flex-col items-center justify-center min-h-screen bg-[hsl(var(--board-bg))]">
       <h1 className="text-4xl font-bold mb-8">Tic-Tac-Toe</h1>
       {(() => {
         const renderMinRow = minRow - 1
@@ -138,8 +143,8 @@ const XOGame = () => {
               <Button
                 key={key}
                 onClick={() => handleClick(r, c)}
-                className="w-20 h-20 text-4xl font-bold"
-                variant={cell ? "default" : "outline"}
+                className={`w-20 h-20 text-4xl font-bold ${cell === 'X' ? 'text-[hsl(var(--x-color))]' : cell === 'O' ? 'text-[hsl(var(--o-color))]' : ''}`}
+                variant={cell ? 'default' : 'outline'}
                 disabled={!!cell || !!winner}
               >
                 {cell}
@@ -149,7 +154,7 @@ const XOGame = () => {
         }
         return (
           <div
-            className="grid gap-2 mb-4"
+            className="grid gap-2 mb-4 bg-[hsl(var(--board-bg))]"
             style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
           >
             {cells}
@@ -163,7 +168,10 @@ const XOGame = () => {
           ? "It's a draw!"
           : `Current player: ${currentPlayer}`}
       </div>
-      <Button onClick={resetGame} className="px-4 py-2 mb-4">
+      <Button
+        onClick={resetGame}
+        className="px-4 py-2 mb-4 bg-accent text-accent-foreground hover:bg-accent/90"
+      >
         Reset Game
       </Button>
       {isInstallable && (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,14 +32,17 @@ const config: Config = {
   				DEFAULT: 'hsl(var(--muted))',
   				foreground: 'hsl(var(--muted-foreground))'
   			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
+                        accent: {
+                                DEFAULT: 'hsl(var(--accent))',
+                                foreground: 'hsl(var(--accent-foreground))'
+                        },
+                        x: 'hsl(var(--x-color))',
+                        o: 'hsl(var(--o-color))',
+                        board: 'hsl(var(--board-bg))',
+                        destructive: {
+                                DEFAULT: 'hsl(var(--destructive))',
+                                foreground: 'hsl(var(--destructive-foreground))'
+                        },
   			border: 'hsl(var(--border))',
   			input: 'hsl(var(--input))',
   			ring: 'hsl(var(--ring))',


### PR DESCRIPTION
## Summary
- define CSS variables for board, player, and accent hues
- expose new variables in Tailwind theme
- color game board, cells, and primary buttons using new accents

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a64b4480832cb92b399d694c1c12