### PR TITLE
Enable one-player mode selection and preserve game mode

### DIFF
--- a/components/xo-game.tsx
+++ b/components/xo-game.tsx
@@ -99,7 +99,6 @@ const XOGame = () => {
     setCurrentPlayer('X')
     setWinner(null)
     setGameStarted(false)
-    setGameMode('2p')
   }
 
   if (!gameStarted) {
@@ -107,7 +106,12 @@ const XOGame = () => {
       <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
         <h1 className="text-4xl font-bold mb-8">Tic-Tac-Toe</h1>
         <div className="flex gap-4 mb-4">
-          <Button disabled>1 Player (bot)</Button>
+          <Button
+            variant={gameMode === '1p' ? 'default' : 'outline'}
+            onClick={() => setGameMode('1p')}
+          >
+            1 Player (bot)
+          </Button>
           <Button
             variant={gameMode === '2p' ? 'default' : 'outline'}
             onClick={() => setGameMode('2p')}


### PR DESCRIPTION
## Summary
- Enable selection of 1-player (bot) mode with interactive button
- Preserve selected game mode when resetting the game

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a876292c832cb3740abb3079a178