### PR TITLE
Generalize winner detection to arbitrary coordinates

### DIFF
--- a/components/__tests__/xo-game.test.tsx
+++ b/components/__tests__/xo-game.test.tsx
@@ -38,6 +38,15 @@ describe('checkWinner', () => {
     expect(checkWinner(board)).toBe('O')
   })
 
+  it('handles negative coordinates in a win', () => {
+    const board: Board = {
+      '-1,-1': 'X',
+      '0,0': 'X',
+      '1,1': 'X',
+    }
+    expect(checkWinner(board)).toBe('X')
+  })
+
   it('returns null for a draw', () => {
     const board: Board = {
       '0,0': 'X', '0,1': 'O', '0,2': 'X',

--- a/lib/check-winner.ts
+++ b/lib/check-winner.ts
@@ -5,31 +5,29 @@ export type Board = Record<string, Player>
 // Scans a dynamic board for any horizontal, vertical or diagonal sequence of
 // three identical symbols. The board is represented as a record keyed by
 // "row,col". Only occupied cells need to be present.
+// Directions to search: horizontal, vertical, diagonal and anti-diagonal.
+const directions: Array<[number, number]> = [
+  [1, 0],
+  [0, 1],
+  [1, 1],
+  [1, -1],
+]
+
 export const checkWinner = (board: Board): Player => {
-  // Directions: horizontal, vertical, diagonal, anti-diagonal
-  const directions: Array<[number, number]> = [
-    [1, 0],
-    [0, 1],
-    [1, 1],
-    [1, -1],
-  ]
-
-  for (const key of Object.keys(board)) {
-    const player = board[key]
+  for (const [key, player] of Object.entries(board)) {
     if (!player) continue
-
     const [row, col] = key.split(',').map(Number)
 
-    for (const [dr, dc] of directions) {
+    for (const [dRow, dCol] of directions) {
       let count = 1
-      let r = row + dr
-      let c = col + dc
+      let r = row + dRow
+      let c = col + dCol
 
       while (board[`${r},${c}`] === player) {
         count++
         if (count >= 3) return player
-        r += dr
-        c += dc
+        r += dRow
+        c += dCol
       }
     }
   }


### PR DESCRIPTION
## Summary
- Generalize win checking by scanning any occupied coordinates in horizontal, vertical, or diagonal directions.
- Add tests for handling negative-coordinate wins.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a99111a4832cb265806240520851