### PR TITLE
feat: require five in a row to win

### DIFF
--- a/components/__tests__/xo-game.test.tsx
+++ b/components/__tests__/xo-game.test.tsx
@@ -7,6 +7,8 @@ describe('checkWinner', () => {
       '5,5': 'X',
       '5,6': 'X',
       '5,7': 'X',
+      '5,8': 'X',
+      '5,9': 'X',
     }
     expect(checkWinner(board)).toBe('X')
   })
@@ -16,6 +18,8 @@ describe('checkWinner', () => {
       '5,5': 'O',
       '6,5': 'O',
       '7,5': 'O',
+      '8,5': 'O',
+      '9,5': 'O',
     }
     expect(checkWinner(board)).toBe('O')
   })
@@ -25,15 +29,19 @@ describe('checkWinner', () => {
       '5,5': 'X',
       '6,6': 'X',
       '7,7': 'X',
+      '8,8': 'X',
+      '9,9': 'X',
     }
     expect(checkWinner(board)).toBe('X')
   })
 
   it('detects an anti-diagonal win away from the origin', () => {
     const board: Board = {
-      '7,5': 'O',
-      '6,6': 'O',
-      '5,7': 'O',
+      '9,5': 'O',
+      '8,6': 'O',
+      '7,7': 'O',
+      '6,8': 'O',
+      '5,9': 'O',
     }
     expect(checkWinner(board)).toBe('O')
   })

--- a/components/xo-game.tsx
+++ b/components/xo-game.tsx
@@ -78,7 +78,7 @@ const XOGame = () => {
           c += dc * dir
         }
       }
-      if (count >= 3) {
+      if (count >= 5) {
         foundWinner = currentPlayer
         break
       }

--- a/lib/check-winner.ts
+++ b/lib/check-winner.ts
@@ -3,7 +3,7 @@ export type Player = 'X' | 'O' | null
 export type Board = Record<string, Player>
 
 // Scans a dynamic board for any horizontal, vertical or diagonal sequence of
-// three identical symbols. The board is represented as a record keyed by
+// five identical symbols. The board is represented as a record keyed by
 // "row,col". Only occupied cells need to be present.
 export const checkWinner = (board: Board): Player => {
   // Directions: horizontal, vertical, diagonal, anti-diagonal
@@ -27,7 +27,7 @@ export const checkWinner = (board: Board): Player => {
 
       while (board[`${r},${c}`] === player) {
         count++
-        if (count >= 3) return player
+        if (count >= 5) return player
         r += dr
         c += dc
       }


### PR DESCRIPTION
## Summary
- enforce five-in-a-row rule in winner detection logic
- update game component to match new win condition
- adjust tests for five-token sequences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897aacf0e0c832ca256bb9fbfb37c5b